### PR TITLE
fix: Remove duplicate points

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.28.0-alpha2"
+version = "0.28.0-alpha3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"


### PR DESCRIPTION
1. Remove duplicate points from delaunay triangulation to prevent intersecting triangles
2. Raise an error in voronoi diagram if triangluation is not valid delaunay