### PR TITLE
Add documentation + clean traits

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -112,3 +112,7 @@ harness = false
 [[bench]]
 name = "monotone_subdiv"
 harness = false
+
+[[bench]]
+name = "delaunay_diagram"
+harness = false

--- a/geo/benches/delaunay_diagram.rs
+++ b/geo/benches/delaunay_diagram.rs
@@ -1,0 +1,48 @@
+use criterion::{criterion_group, criterion_main};
+use geo::coord;
+use geo::{polygon, Polygon, TriangulateDelaunay, TriangulateSpade};
+
+fn get_polygon() -> Polygon {
+    polygon![
+        coord! { x: 10., y: 10.},
+        coord! { x: 10., y: 20.},
+        coord! { x: 20., y: 20.},
+        coord! { x: 20., y: 10.},
+        coord! { x: 10., y: 0.},
+        coord! { x: 10., y: 0.},
+        coord! { x: 0., y: 10.},
+        coord! { x: 0., y: 20.},
+    ]
+}
+
+fn criterion_benchmark(c: &mut criterion::Criterion) {
+    c.bench_function("Delaunay Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| poly.delaunay_triangulation().unwrap())
+    });
+
+    c.bench_function("Spade Unconstrained Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| {
+            poly.unconstrained_triangulation().unwrap();
+        })
+    });
+
+    c.bench_function("Constrained Outer Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| {
+            poly.constrained_outer_triangulation(Default::default())
+                .unwrap();
+        })
+    });
+
+    c.bench_function("Constrain Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| {
+            poly.constrained_triangulation(Default::default()).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -265,6 +265,8 @@ pub use triangulate_delaunay::TriangulateDelaunay;
 
 #[cfg(feature = "voronoi")]
 pub mod voronoi_diagram;
+#[cfg(feature = "voronoi")]
+pub use voronoi_diagram::VoronoiDiagram;
 
 /// Vector Operations for 2D coordinates
 mod vector_ops;

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -11,9 +11,9 @@ type Result<T> = std::result::Result<T, DelaunayTriangulationError>;
 /// [Bowyer](https://doi.org/10.1093%2Fcomjnl%2F24.2.162)-[Watson](https://doi.org/10.1093%2Fcomjnl%2F24.2.167)
 /// algorithm
 pub trait TriangulateDelaunay<T: GeoFloat> {
-    /// # Examples
+    /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use geo::{coord, polygon, Triangle, TriangulateDelaunay};
     ///
     /// let points = polygon![
@@ -320,7 +320,8 @@ pub enum DelaunayTriangulationError {
     /// This error occurs when the `Polygon` describing the points to
     /// triangulate does not return a bounding rectangle.
     FailedToConstructSuperTriangle,
-    FailedToConvertSuperTriangleFactor,
+    /// Failed to convert value into generic type T.
+    /// This error occurs when the value 2.0 cannot be converted into T.
     GeoTypeConversionError,
 }
 
@@ -338,9 +339,6 @@ impl fmt::Display for DelaunayTriangulationError {
             }
             DelaunayTriangulationError::GeoTypeConversionError => {
                 write!(f, "Failed to convert from Geo type T")
-            }
-            DelaunayTriangulationError::FailedToConvertSuperTriangleFactor => {
-                write!(f, "Failed to convert super triangle expansion factor")
             }
         }
     }

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -3,7 +3,10 @@ use std::{fmt, fmt::Debug};
 use crate::coord;
 use crate::{BoundingRect, Coord, GeoFloat, Line, MultiPoint, Polygon, Triangle};
 
-const DEFAULT_SUPER_TRIANGLE_EXPANSION: f64 = 20.;
+/// The default expansion value for creating the super triangle.
+/// A bounding rectangle is computed for the points and the super triangle
+/// is expanded by this value by default.
+pub const DEFAULT_SUPER_TRIANGLE_EXPANSION: f64 = 20.;
 
 type Result<T> = std::result::Result<T, DelaunayTriangulationError>;
 

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -225,22 +225,10 @@ where
     f64: From<T>,
 {
     #[cfg(feature = "voronoi")]
-    /// Check if a `DelaunayTriangle` shares at least one vertex.
-    pub fn shares_vertex(&self, other: &DelaunayTriangle<T>) -> bool {
-        let other_vertices = other.0.to_array();
-        for vertex in self.0.to_array().iter() {
-            if other_vertices.contains(vertex) {
-                return true;
-            }
-        }
-        false
-    }
-
-    #[cfg(feature = "voronoi")]
     /// Check if a `DelaunayTriangle` is a neighbour i.e.
     /// shares an edge.
     /// If the triangles are neighbours the shared edge is returned.
-    pub fn shares_edge(&self, other: &DelaunayTriangle<T>) -> Option<Line<T>> {
+    pub(crate) fn shares_edge(&self, other: &DelaunayTriangle<T>) -> Option<Line<T>> {
         let other_lines = other.0.to_lines();
         for line in self.0.to_lines().iter() {
             for other_line in other_lines.iter() {
@@ -257,7 +245,7 @@ where
     /// This method uses the determinant of the vertices of the triangle and the
     /// new point as described by [Guibas & Stolfi](https://doi.org/10.1145%2F282918.282923)
     /// and on [Wikipedia](https://en.wikipedia.org/wiki/Delaunay_triangulation#Algorithms).
-    pub fn is_in_circumcircle(&self, c: &Coord<T>) -> bool {
+    pub(crate) fn is_in_circumcircle(&self, c: &Coord<T>) -> bool {
         let a_d_x: f64 = (self.0 .0.x - c.x).into();
         let a_d_y: f64 = (self.0 .0.y - c.y).into();
         let b_d_x: f64 = (self.0 .1.x - c.x).into();
@@ -285,7 +273,7 @@ where
     #[cfg(feature = "voronoi")]
     /// Get the center of the [Circumcircle](https://en.wikipedia.org/wiki/Circumcircle)
     /// for the Delaunay triangle.
-    pub fn get_circumcircle_centre(&self) -> Result<Coord<T>> {
+    pub(crate) fn get_circumcircle_centre(&self) -> Result<Coord<T>> {
         // Pin the triangle to the origin to simplify the calculation
         let b = self.0 .1 - self.0 .0;
         let c = self.0 .2 - self.0 .0;
@@ -352,30 +340,6 @@ mod test {
     use super::*;
     use crate::Contains;
     use geo_types::{LineString, MultiPoint, Point};
-
-    #[test]
-    fn test_triangle_shares_vertex() {
-        let triangle = DelaunayTriangle(Triangle::new(
-            coord! {x: 0., y: 0.},
-            coord! {x: 10., y: 20.},
-            coord! {x: -12., y: -2.},
-        ));
-        let other = DelaunayTriangle(Triangle::new(
-            coord! {x: 0., y: 0.},
-            coord! {x: 30., y: 40.},
-            coord! {x: 40., y: 30.},
-        ));
-
-        assert!(triangle.shares_vertex(&other));
-
-        let other = DelaunayTriangle(Triangle::new(
-            coord! {x: 30., y: 40.},
-            coord! {x: 40., y: 30.},
-            coord! {x: 50., y: 20.},
-        ));
-
-        assert!(!triangle.shares_vertex(&other));
-    }
 
     #[test]
     fn test_triangle_is_neighbour() {

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -3,7 +3,7 @@ use std::{fmt, fmt::Debug};
 use crate::coord;
 use crate::{BoundingRect, Coord, GeoFloat, Line, MultiPoint, Polygon, Triangle};
 
-pub const DEFAULT_SUPER_TRIANGLE_EXPANSION: f64 = 20.;
+const DEFAULT_SUPER_TRIANGLE_EXPANSION: f64 = 20.;
 
 type Result<T> = std::result::Result<T, DelaunayTriangulationError>;
 
@@ -282,7 +282,7 @@ where
     #[cfg(feature = "voronoi")]
     /// Get the center of the [Circumcircle](https://en.wikipedia.org/wiki/Circumcircle)
     /// for the Delaunay triangle.
-    pub fn get_circumcircle_center(&self) -> Result<Coord<T>> {
+    pub fn get_circumcircle_centre(&self) -> Result<Coord<T>> {
         // Pin the triangle to the origin to simplify the calculation
         let b = self.0 .1 - self.0 .0;
         let c = self.0 .2 - self.0 .0;
@@ -421,7 +421,7 @@ mod test {
             coord! {x: 30., y: 10.},
         ));
 
-        let circle_center = triangle.get_circumcircle_center().unwrap();
+        let circle_center = triangle.get_circumcircle_centre().unwrap();
         approx::assert_relative_eq!(circle_center, coord! {x: 20., y: 10.});
     }
 
@@ -436,7 +436,7 @@ mod test {
         // The circumcircle for collinear points cannot be
         // determined as the radius would be infinite
         triangle
-            .get_circumcircle_center()
+            .get_circumcircle_centre()
             .expect_err("Cannot compute circumcircle");
     }
 

--- a/geo/src/algorithm/voronoi_diagram.rs
+++ b/geo/src/algorithm/voronoi_diagram.rs
@@ -31,7 +31,7 @@ pub struct VoronoiComponents<T: GeoFloat> {
     /// This is an index of Delaunay triangles that are / have neighours
     /// the first value is the index of the triangle and the second value
     /// is the index of a neighbouring triangle.
-    /// If the triangle does not have a neighbour the value is None.
+    /// If the triangle does not have a neighbour the value is `None`.
     pub neighbours: Vec<(Option<usize>, Option<usize>)>,
 }
 
@@ -39,7 +39,7 @@ pub struct VoronoiComponents<T: GeoFloat> {
 /// the Voronoi diagram.
 pub type ClippingMask<T> = Polygon<T>;
 
-/// Compute the Voronoi Diagram for a given set of points.
+/// Compute the Voronoi diagram for a given set of points.
 /// This method uses the property that Delaunay triangulation
 /// [is a dual graph](https://en.wikipedia.org/wiki/Delaunay_triangulation#Relationship_with_the_Voronoi_diagram)
 /// of the Voronoi diagram.
@@ -379,7 +379,7 @@ impl CircumCentreLocation {
     }
 }
 
-// Get the inifinity line from inside to outside the triangle
+// Get the inifinity line from inside to outside the triangle.
 // Infinity lines that start from within the triangle to outside
 // need to start at the circumcentre and move towards infinity.
 fn get_inf_line_in_out_triangle<T: GeoFloat>(tmp_line: Line<T>, circumcentre: &Coord<T>) -> Line<T>
@@ -419,7 +419,7 @@ where
 }
 
 // Get the infinity line that lies outside of the
-// Delaunay triangle
+// Delaunay triangle.
 fn get_inf_outside_triangle<T: GeoFloat>(
     triangle: &Triangle<T>,
     circumcentre: &Coord<T>,
@@ -626,7 +626,7 @@ where
     Some(Line::new(inf_line.start, coord! { x: p_x, y: p_y}))
 }
 
-// Construct the edges to infinity
+// Construct the edges to infinity.
 fn construct_edges_to_inf<T: GeoFloat>(
     triangles: &[DelaunayTriangle<T>],
     vertices: &[Coord<T>],
@@ -696,11 +696,11 @@ where
     Ok(inf_lines)
 }
 
-/// Voronoi Diagram Errors
+/// Voronoi diagram errors.
 #[derive(Debug, PartialEq, Eq)]
 pub enum VoronoiDiagramError {
-    /// An error occurred when attempting to complete Delaunay Triangulation
-    /// before computing the Voronoi Diagram.
+    /// An error occurred when attempting to complete Delaunay triangulation
+    /// before computing the Voronoi diagram.
     DelaunayError(DelaunayTriangulationError),
     /// This error occurs when a value cannot be converted to the core
     /// number type of the [`Polygon`] or [`MultiPoint`] being used to generate
@@ -1101,9 +1101,7 @@ mod test {
 
     #[test]
     fn test_inf_on_midpoint_triangle() {
-        // The midpoint falls on the circumcentre for
-        // right triangles
-        // Triangle facing left
+        // The midpoint falls on the circumcentre for right triangles.
         let triangle = Triangle::new(
             coord! {x: 0., y:0.},
             coord! {x: 0., y: 3.},

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -108,7 +108,9 @@
 //!
 //! ## Triangulation
 //!
+//! - **[`TriangulateDelaunay`](triangulate_delaunay)**: Delaunay triangulation using the [Bowyer-Watson](https://en.wikipedia.org/wiki/Bowyer%E2%80%93Watson_algorithm) method.
 //! - **[`TriangulateEarcut`](triangulate_earcut)**: Triangulate polygons using the earcut algorithm (requires the `earcutr` feature).
+//! - **[`TriangulateSpade`](triangulate_spade)**: Delaunay triangulation via the [spade](https://docs.rs/spade/latest/spade/) crate.
 //!
 //! ## Winding
 //!
@@ -168,6 +170,7 @@
 //! - **[`LineStringSegmentize`]**: Segment a LineString into `n` segments.
 //! - **[`Transform`]**: Transform a geometry using Proj.
 //! - **[`RemoveRepeatedPoints`]**: Remove repeated points from a geometry.
+//! - **[`VoronoiDiagram`](voronoi_diagram)**: Calculate the Voronoi diagram for a [`Polygon`] or [`MultiPolygon`].
 //!
 //! # Features
 //!


### PR DESCRIPTION
* Remove unimplemented function from `VoronoiDiagram` trait
* Add documentation for `voronoi_diagram` file
* Add benchmark tests for alternate delaunay triangulation methods.

The results of the bench mark when executed on my machine are:

```
Delaunay Triangulation  time:   [2.2839 µs 2.3687 µs 2.4780 µs]
                        change: [-21.682% -14.728% -7.0971%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Spade Unconstrained Triangulation
                        time:   [1.4216 µs 1.4831 µs 1.5582 µs]
                        change: [+39.411% +46.250% +53.808%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

Constrained Outer Triangulation
                        time:   [3.5185 µs 3.7830 µs 4.1260 µs]

Constrain Triangulation time:   [3.5962 µs 3.7355 µs 3.8970 µs]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe
```

